### PR TITLE
[codex] Refresh RCN Dallas website design

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,10 +55,13 @@
         <!-- SECTION: HERO -->
         <section class="hero-section">
             <div class="hero-content">
-                <div class="hero-icon-circle">R</div>
+                <p class="hero-kicker" data-i18n="hero_kicker">Remnant Christian Network · Dallas</p>
                 <h1 data-i18n="rcn_dallas_full_title">Remnant Christian Network <span class="subtitle-hero">Dallas, TX</span></h1>
                 <p class="tagline" data-i18n="rcn_tagline">Striving for the Rebirth of Apostolic Christianity</p>
-                <a href="#prayer-services-section" class="btn btn-primary" data-i18n="join_us_sunday">Join Us In Person</a>
+                <div class="hero-actions">
+                    <a href="#prayer-services-section" class="btn btn-primary" data-i18n="join_us_sunday">Join Us In Person</a>
+                    <a href="#about-rcn-section" class="btn btn-quiet" data-i18n="hero_about_cta">About RCN Dallas</a>
+                </div>
             </div>
             <div class="hero-info-cards" id="prayer-services-section">
                 <div class="info-card">
@@ -76,17 +79,11 @@
         <section class="page-section bg-light" id="current-campaigns-section">
             <div class="container">
                 <h2 class="section-title" data-i18n="section_title_campaigns">Current Campaigns</h2>
-                <div class="grid-2-col">
+                <div class="campaign-single">
                     <div class="campaign-card style-2">
                         <span class="campaign-tag" data-i18n="campaign_active_tag">Active Campaign</span>
                         <h3 data-i18n="campaign_promise_title">Midday Prayers: Every Day at Noon</h3>
                         <p data-i18n="campaign_promise_desc">Join us daily at 12PM CDT for powerful midday prayers on Zoom.</p>
-                        <a href="https://chat.whatsapp.com/LNBlcBaH5XF3JwosqkcpNJ?mode=gi_t" class="btn btn-light" data-i18n="btn_join_now" target="_blank">Join Now</a>
-                    </div>
-                    <div class="campaign-card">
-                        <span class="campaign-tag" data-i18n="campaign_active_tag">Active Campaign</span>
-                        <h3 data-i18n="campaign_100_days_title">Nightly Prayer Services</h3>
-                        <p data-i18n="campaign_100_days_desc">Join us in seeking God's face in prayer every night at 11PM CDT on Zoom</p>
                         <a href="https://chat.whatsapp.com/LNBlcBaH5XF3JwosqkcpNJ?mode=gi_t" class="btn btn-light" data-i18n="btn_join_now" target="_blank">Join Now</a>
                     </div>
                 </div>
@@ -100,14 +97,14 @@
                 <p class="section-subtitle" data-i18n="new_to_rcn_subtitle">We're excited to welcome you into our church family. Here's everything you need to know for your first visit.</p>
                 <div class="grid-3-col">
                     <div class="visitor-card">
-                    <img src="images/visit-location.jpg" alt="Exterior view of RCN Dallas church building" class="visitor-card-image" loading="lazy">
+                    <img src="images/visit-location.jpg?v=20260602" alt="Exterior view of RCN Dallas church building" class="visitor-card-image" loading="lazy">
                         <div class="visitor-card-content">
                         <h4 data-i18n="new_location_time_title">Location & Time</h4>
-                        <p data-i18n="new_location_time_desc">Join us for worship on the 1st and 4th Saturdays of the month from 7AM-5PM</p>
+                        <p data-i18n="new_location_time_desc">1012 E Wintergreen Road, DeSoto, TX 75115 — Join us for worship on the 1st and 4th Saturdays of the month from 7AM-5PM</p>
                         </div>
                     </div>
                     <div class="visitor-card">
-                    <img src="images/visit-prayer.jpg" alt="Congregation participating in a prayer service" class="visitor-card-image" loading="lazy">
+                    <img src="images/visit-prayer.jpg" alt="Wednesday Night Service flyer: Establishing Priesthood with Rev. Philip Gbir, 10PM–12AM on Zoom" class="visitor-card-image" loading="lazy">
                         <div class="visitor-card-content">
                         <h4 data-i18n="new_prayer_services_title">Mid week services</h4>
                         <p data-i18n="new_prayer_services_desc">Join us midweek for services every Wednesday at 10PM via Zoom</p>
@@ -150,17 +147,11 @@
                 <h2 class="section-title" data-i18n="section_title_events">Upcoming Events</h2>
                 <p class="section-subtitle" data-i18n="events_subtitle">Stay up-to-date with our latest gatherings, special services, and community activities.</p>
                 
-                <div class="grid-2-col">
-                    <div class="campaign-card">
-                        <span class="campaign-tag" data-i18n="event_one_accord_tag">Upcoming Event</span>
-                        <h3 data-i18n="event_one_accord_title">One Accord</h3>
-                        <p data-i18n="event_one_accord_desc">Join us for a powerful service with Rev. Philip Gbir on Saturday, April 4th, 2026 at 7AM. Location: 745 Brown Trail, Hurst, TX 76053</p>
-                        <a href="https://chat.whatsapp.com/LNBlcBaH5XF3JwosqkcpNJ?mode=gi_t" class="btn btn-light" data-i18n="btn_join_now" target="_blank">Join Now</a>
-                    </div>
+                <div class="campaign-single">
                     <div class="campaign-card style-2">
                         <span class="campaign-tag" data-i18n="event_prayer_cruise_tag">Upcoming Event</span>
                         <h3 data-i18n="event_prayer_cruise_title">5 Hour Prayer Cruise</h3>
-                        <p data-i18n="event_prayer_cruise_desc">Join us for a powerful 5-hour prayer service on Saturday, March 28th, 2026 from 8AM-1PM. Location: 745 Brown Trail, Hurst, TX 76053</p>
+                        <p data-i18n="event_prayer_cruise_desc">Join us for a powerful 5-hour prayer service on Saturday, June 27th, 2026 from 8AM-1PM. Location: 1012 E Wintergreen Road, DeSoto, TX 75115</p>
                         <a href="https://chat.whatsapp.com/LNBlcBaH5XF3JwosqkcpNJ?mode=gi_t" class="btn btn-light" data-i18n="btn_join_now" target="_blank">Join Now</a>
                     </div>
                 </div>
@@ -429,7 +420,7 @@
             <a href="https://www.instagram.com/rcndallastx?utm_source=ig_web_button_share_sheet&igsh=MW5zMnFiNjNxdWJmeA==" target="_blank" aria-label="Instagram" data-i18n="social_instagram">Instagram</a>
             <a href="https://youtube.com/@rcndallastx?si=kjF3C1RigQNmNGIN">YouTube</a>
         </div>
-        <p data-i18n="footer_text">© 2025 Remnant Christian Network. Made with ❤️.</p>
+        <p data-i18n="footer_text">© 2026 Remnant Christian Network. Made with ❤️.</p>
     </footer>
 
     <script>
@@ -484,15 +475,15 @@
                     nav_events: "Events",
                     nav_give: "Give",
                     lang_button_text: "ES",
+                    hero_kicker: "Remnant Christian Network · Dallas",
                     rcn_dallas_full_title: "Remnant Christian Network <span class=\"subtitle-hero\">Dallas, TX</span>",
                     rcn_tagline: "Striving for the rebirth of Apostolic Christianity",
                     join_us_sunday: "Join Us In Person",
+                    hero_about_cta: "About RCN Dallas",
                     prayer_services_info: "10-Hour Prayer Services: 1st Saturday of Month | 7AM-5PM",
                     worship_info: "5-Hour Prayer Services: 4th Saturday of Month | 8AM-1PM",
                     section_title_campaigns: "Current Campaigns",
                     campaign_active_tag: "Active Campaign",
-                    campaign_100_days_title: "Nightly Prayer Services",
-                    campaign_100_days_desc: "Join us in seeking God's face in prayer every night at 11PM CDT on Zoom",
                     btn_learn_more: "Learn More",
                     campaign_upcoming_tag: "Upcoming",
                     campaign_promise_title: "Midday Prayers: Every Day at Noon",
@@ -501,7 +492,7 @@
                     section_title_new_to_rcn: "New to RCN Dallas?",
                     new_to_rcn_subtitle: "We're excited to welcome you into our church family. Here's everything you need to know for your first visit.",
                     new_location_time_title: "Location & Time",
-                    new_location_time_desc: "Join us for worship on the 1st and 4th Saturdays of the month from 7AM-5PM",
+                    new_location_time_desc: "1012 E Wintergreen Road, DeSoto, TX 75115 — Join us for worship on the 1st and 4th Saturdays of the month from 7AM-5PM",
                     new_prayer_services_title: "Mid week services",
                     new_prayer_services_desc: "Join us midweek for services every Wednesday at 10PM via Zoom",
                     new_what_to_expect_title: "What to Expect",
@@ -528,12 +519,9 @@
                     section_title_events: "Upcoming Events",
                     events_subtitle: "Stay up-to-date with our latest gatherings, special services, and community activities.",
                     no_upcoming_events: "No upcoming events at this time. Check back soon for new gatherings and special services!",
-                    event_one_accord_tag: "Upcoming Event",
-                    event_one_accord_title: "One Accord",
-                    event_one_accord_desc: "Join us for a powerful service with Rev. Philip Gbir on Saturday, April 4th, 2026 at 7AM. Location: 745 Brown Trail, Hurst, TX 76053",
                     event_prayer_cruise_tag: "Upcoming Event",
                     event_prayer_cruise_title: "5 Hour Prayer Cruise",
-                    event_prayer_cruise_desc: "Join us for a powerful 5-hour prayer service on Saturday, March 28th, 2026 from 8AM-1PM. Location: 745 Brown Trail, Hurst, TX 76053",
+                    event_prayer_cruise_desc: "Join us for a powerful 5-hour prayer service on Saturday, June 27th, 2026 from 8AM-1PM. Location: 1012 E Wintergreen Road, DeSoto, TX 75115",
                     section_title_partner: "Partner With Us",
                     partner_subtitle: "Your generosity helps us continue our mission to restore apostolic order and build God's kingdom through prayer, worship, and community.",
                     partner_onetime_title: "One-Time Gift",
@@ -545,7 +533,7 @@
                     partner_monthly_desc: "Become a monthly partner and help us plan for consistent ministry impact",
                     btn_partner_monthly: "Partner Monthly",
                     partner_disclaimer: "RCN Dallas is a registered 501(c)(3) organization. All donations are tax-deductible.",
-                    footer_text: "© 2025 Remnant Christian Network. Made with ❤️.",
+                    footer_text: "© 2026 Remnant Christian Network. Made with ❤️.",
                     social_instagram: "Instagram",
                     social_youtube: "YouTube"
                 },
@@ -559,15 +547,15 @@
                     nav_events: "Eventos",
                     nav_give: "Donar",
                     lang_button_text: "EN",
+                    hero_kicker: "Red Cristiana Remanente · Dallas",
                     rcn_dallas_full_title: "Red Cristiana Remanente <span class=\"subtitle-hero\">Dallas, TX</span>",
                     rcn_tagline: "Luchando por el Renacimiento de la Cristiandad Apostólica",
                     join_us_sunday: "Únete En Persona",
+                    hero_about_cta: "Acerca de RCN Dallas",
                     prayer_services_info: "Servicios de Oración de 10 Horas: 1er Sábado del Mes | 7AM-5PM",
                     worship_info: "Servicios de Oración de 5 Horas: 4to Sábado del Mes | 8AM-1PM",
                     section_title_campaigns: "Campañas Actuales",
                     campaign_active_tag: "Campaña Activa",
-                    campaign_100_days_title: "Servicios de Oración Nocturnos",
-                    campaign_100_days_desc: "Únete a nosotros en la búsqueda del rostro de Dios en oración cada noche a las 11PM CDT en Zoom",
                     btn_learn_more: "Saber Más",
                     campaign_upcoming_tag: "Próximo",
                     campaign_promise_title: "Oraciones del Mediodía: Todos los Días al Mediodía",
@@ -576,7 +564,7 @@
                     section_title_new_to_rcn: "¿Nuevo en RCN Dallas?",
                     new_to_rcn_subtitle: "Estamos emocionados de darle la bienvenida a nuestra familia de la iglesia. Aquí encontrará todo lo que necesita saber para su primera visita.",
                     new_location_time_title: "Ubicación y Hora",
-                    new_location_time_desc: "Únase a nosotros para el culto el primer y cuarto sábado de cada mes de 7 AM a 5 PM",
+                    new_location_time_desc: "1012 E Wintergreen Road, DeSoto, TX 75115 — Únase a nosotros para el culto el primer y cuarto sábado de cada mes de 7 AM a 5 PM",
                     new_prayer_services_title: "Servicios de mitad de semana",
                     new_prayer_services_desc: "Únase a nosotros a mitad de semana para los servicios todos los miércoles a las 10PM vía Zoom",
                     new_what_to_expect_title: "Qué Esperar",
@@ -603,12 +591,9 @@
                     section_title_events: "Próximos Eventos",
                     events_subtitle: "Manténgase al día con nuestras últimas reuniones, servicios especiales y actividades comunitarias.",
                     no_upcoming_events: "No hay eventos próximos en este momento. ¡Vuelva pronto para nuevas reuniones y servicios especiales!",
-                    event_one_accord_tag: "Próximo Evento",
-                    event_one_accord_title: "Un Solo Acuerdo",
-                    event_one_accord_desc: "Únase a nosotros para un servicio poderoso con el Rev. Philip Gbir el sábado 4 de abril de 2026 a las 7AM. Ubicación: 745 Brown Trail, Hurst, TX 76053",
                     event_prayer_cruise_tag: "Próximo Evento",
                     event_prayer_cruise_title: "Crucero de Oración de 5 Horas",
-                    event_prayer_cruise_desc: "Únase a nosotros para un poderoso servicio de oración de 5 horas el sábado 28 de marzo de 2026 de 8AM-1PM. Ubicación: 745 Brown Trail, Hurst, TX 76053",
+                    event_prayer_cruise_desc: "Únase a nosotros para un poderoso servicio de oración de 5 horas el sábado 27 de junio de 2026 de 8AM-1PM. Ubicación: 1012 E Wintergreen Road, DeSoto, TX 75115",
                     section_title_partner: "Asóciate con Nosotros",
                     partner_subtitle: "Su generosidad nos ayuda a continuar nuestra misión de restaurar el orden apostólico y construir el reino de Dios a través de la oración, la adoración y la comunidad.",
                     partner_onetime_title: "Donación Única",
@@ -620,7 +605,7 @@
                     partner_monthly_desc: "Conviértase en un socio mensual y ayúdenos a planificar un impacto ministerial constante",
                     btn_partner_monthly: "Asociarse Mensualmente",
                     partner_disclaimer: "RCN Dallas es una organización 501(c)(3) registrada. Todas las donaciones son deducibles de impuestos.",
-                    footer_text: "© 2025 Red Cristiana Remanente. Hecho con ❤️.",
+                    footer_text: "© 2026 Red Cristiana Remanente. Hecho con ❤️.",
                     social_instagram: "Instagram",
                     social_youtube: "YouTube"
                 }

--- a/style.css
+++ b/style.css
@@ -1,16 +1,20 @@
 /* --- 1. GLOBAL STYLES & VARIABLES --- */
 :root {
-    --color-primary-start: #6A3FDB;
-    --color-primary-end: #2B3A8E;
-    --gradient-primary: linear-gradient(90deg, var(--color-primary-start) 0%, var(--color-primary-end) 100%);
-    --gradient-secondary: linear-gradient(135deg, #8A63F8 0%, #5A58E6 100%);
+    --color-primary-start: #6a3fdb;
+    --color-primary-end: #2b3a8e;
+    --color-accent: #8a63f8;
+    --color-ink: #242331;
+    --color-panel: #f1edff;
+    --gradient-primary: linear-gradient(135deg, var(--color-primary-start) 0%, var(--color-primary-end) 100%);
+    --gradient-secondary: linear-gradient(135deg, #8a63f8 0%, #5a58e6 100%);
 
-    --color-dark: #2c2c2c;
-    --color-grey: #6c757d;
+    --color-dark: var(--color-ink);
+    --color-grey: #6c6a78;
     --color-light: #ffffff;
-    --bg-light: #f7f8fa;
-    --shadow-soft: 0px 10px 30px rgba(0, 0, 0, 0.07);
-    --radius: 16px;
+    --bg-light: #f7f6fb;
+    --border-soft: #e5e1f0;
+    --shadow-soft: 0px 18px 45px rgba(43, 58, 142, 0.1);
+    --radius: 8px;
 
     --font-family: 'Inter', sans-serif;
 }
@@ -32,14 +36,14 @@ html {
 body {
     font-family: var(--font-family);
     color: var(--color-dark);
-    background-color: var(--color-light);
+    background-color: #ffffff;
     line-height: 1.6;
     display: flex;
     flex-direction: column;
 }
 
 .container {
-    max-width: 1200px;
+    max-width: 1180px;
     margin: 0 auto;
     padding: 0 2rem;
 }
@@ -50,8 +54,8 @@ h1, h2, h3, h4 {
     color: var(--color-dark);
 }
 
-h1 { font-size: 3.5rem; }
-h2 { font-size: 2.5rem; }
+h1 { font-size: 3.75rem; }
+h2 { font-size: 2.35rem; }
 h3 { font-size: 1.75rem; }
 h4 { font-size: 1.25rem; }
 
@@ -79,13 +83,14 @@ a { text-decoration: none; }
 }
 
 
-.page-section { padding: 6rem 0; }
+.page-section { padding: 5.5rem 0; }
 .bg-light { background-color: var(--bg-light); }
 .text-center { text-align: center; }
 
 .section-title {
     text-align: center;
     margin-bottom: 1rem;
+    letter-spacing: 0;
 }
 .section-title.align-left { text-align: left; }
 
@@ -96,24 +101,25 @@ a { text-decoration: none; }
 
 /* --- 2. HEADER & NAVIGATION --- */
 .main-header {
-    background: var(--color-light);
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(14px);
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     z-index: 1000;
-    border-bottom: 1px solid #eeeeee;
+    border-bottom: 1px solid rgba(229, 225, 240, 0.9);
 }
 
 .navbar {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    height: 70px;
+    height: 76px;
 }
 
 .logo img {
-    height: 35px;
+    height: 42px;
     width: auto;
 }
 
@@ -125,6 +131,7 @@ a { text-decoration: none; }
     display: flex;
     list-style: none;
     gap: 2.5rem;
+    align-items: center;
 }
 
 .nav-links-main a {
@@ -143,7 +150,7 @@ a { text-decoration: none; }
 .nav-links-main a.active {
     font-weight: 700;
     color: var(--color-primary-start);
-    border-bottom-color: var(--color-primary-start);
+    border-bottom-color: var(--color-accent);
 }
 
 .nav-actions {
@@ -154,7 +161,7 @@ a { text-decoration: none; }
 
 .nav-give-link {
     color: var(--color-dark);
-    font-weight: 500;
+    font-weight: 700;
 }
 
 .nav-give-link:hover {
@@ -167,12 +174,12 @@ a { text-decoration: none; }
 /* --- 3. BUTTONS --- */
 .btn {
     display: inline-block;
-    padding: 12px 28px;
-    border-radius: 50px;
+    padding: 12px 24px;
+    border-radius: var(--radius);
     font-weight: 700;
     border: none;
     cursor: pointer;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 .btn:hover {
     transform: translateY(-2px);
@@ -188,10 +195,19 @@ a { text-decoration: none; }
 }
 .btn-light {
     background: var(--color-light);
-    color: var(--color-primary-start);
+    color: var(--color-primary-end);
+}
+.btn-quiet {
+    background: rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(255, 255, 255, 0.36);
+    color: var(--color-light);
+}
+.btn-quiet:hover {
+    background: rgba(255, 255, 255, 0.24);
 }
 .btn-lang {
-    padding: 7px 18px;
+    padding: 8px 20px;
+    border-radius: 999px;
     font-size: 0.85rem;
     background: var(--gradient-primary);
     color: var(--color-light);
@@ -209,87 +225,103 @@ button:focus,
 
 /* --- 4. HERO SECTION --- */
 .hero-section {
-    background-image: linear-gradient(to right, rgba(43, 58, 142, 0.6), rgba(106, 63, 219, 0.6)), url('images/hero-bg.png');
+    background-image: linear-gradient(90deg, rgba(25, 31, 91, 0.82) 0%, rgba(43, 58, 142, 0.64) 48%, rgba(106, 63, 219, 0.42) 100%), url('images/hero-bg.png');
     background-size: cover;
     background-position: center;
-    min-height: 100vh;
-    padding-top: calc(70px + 2rem);
-    padding-bottom: 6rem;
+    min-height: calc(100vh - 76px);
+    padding: 5rem 0 7rem;
     color: var(--color-light);
-    text-align: center;
+    text-align: left;
     position: relative;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: center;
 }
 
 .hero-content {
-    align-items: center;
-    padding-top: 3rem;
-    flex-grow: 1;
+    width: min(1120px, calc(100% - 4rem));
+    margin: 0 auto;
+    align-items: flex-start;
+    padding-top: 0;
+    flex-grow: 0;
     display: flex;
     flex-direction: column;
     justify-content: center;
 }
 
-.hero-icon-circle {
-    width: 70px;
-    height: 70px;
-    background: var(--gradient-secondary);
-    border-radius: 50%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-size: 2.8rem;
+.hero-kicker {
+    color: rgba(255, 255, 255, 0.78);
+    font-size: 0.8rem;
     font-weight: 800;
-    color: var(--color-light);
-    margin-bottom: 1.5rem;
-    box-shadow: 0px 5px 20px rgba(0,0,0,0.2);
+    letter-spacing: 0;
+    margin-bottom: 1.25rem;
+    text-transform: uppercase;
 }
 
 .hero-content h1 {
     font-weight: 800;
-    margin-bottom: 0.75rem;
+    margin-bottom: 1rem;
     color: inherit;
-    font-size: 3.5rem;
+    font-size: clamp(3rem, 6vw, 5.8rem);
+    max-width: 850px;
 }
 .hero-content .subtitle-hero {
-    font-size: 1.3rem;
-    color: rgba(255,255,255, 0.8);
+    font-size: clamp(1.15rem, 1.6vw, 1.45rem);
+    color: rgba(255,255,255, 0.78);
     display: block;
-    margin-top: 0;
+    margin-top: 0.4rem;
 }
 .hero-content .tagline {
     font-size: 1.1rem;
-    color: rgba(255,255,255, 0.9);
-    margin-bottom: 3rem;
+    color: rgba(255,255,255, 0.86);
+    margin-bottom: 2rem;
+    max-width: 560px;
+}
+.hero-actions {
+    display: flex;
+    gap: 0.85rem;
+    flex-wrap: wrap;
 }
 
 .hero-info-cards {
     display: flex;
-    gap: 1.5rem;
+    gap: 2rem;
     position: absolute;
-    bottom: -40px; /* Adjusted to a negative value to push cards lower */
+    bottom: -54px;
     left: 50%;
     transform: translateX(-50%);
-    max-width: 100%; /* Ensure it doesn't exceed parent width */
-    justify-content: center; /* Center the flex items within this container */
-    flex-wrap: nowrap; /* Keep cards on a single line */
+    width: min(1740px, calc(100% - 10rem));
+    justify-content: center;
+    flex-wrap: nowrap;
 }
 .info-card {
-    background: rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: var(--radius);
-    padding: 1.2rem 2rem;
+    background: linear-gradient(
+        180deg,
+        rgba(78, 79, 174, 0.62) 0%,
+        rgba(91, 76, 190, 0.48) 38%,
+        rgba(255, 255, 255, 0.93) 100%
+    );
+    backdrop-filter: blur(14px);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 24px;
+    box-shadow: 0 15px 35px rgba(43, 58, 142, 0.14);
+    color: var(--color-light);
+    padding: 1.7rem 2.5rem;
     display: flex;
     align-items: center;
-    gap: 1rem;
-    font-size: 1rem;
-    flex-shrink: 0;
+    justify-content: center;
+    gap: 1.5rem;
+    font-size: clamp(1rem, 1.05vw, 1.3rem);
+    flex: 1 1 0;
+    min-height: 108px;
+}
+.info-card span {
+    white-space: nowrap;
 }
 .info-card img {
-    height: 28px;
+    height: 42px;
+    width: auto;
+    flex: 0 0 auto;
 }
 
 
@@ -301,20 +333,26 @@ button:focus,
 
 /* Campaign Cards */
 .campaign-card {
-    padding: 2.5rem;
+    padding: 2rem;
     border-radius: var(--radius);
     color: var(--color-light);
     background: var(--gradient-primary);
+    min-height: 100%;
 }
 .campaign-card.style-2 { background: var(--gradient-secondary); }
 
+.campaign-single {
+    max-width: 560px;
+    margin: 0 auto;
+}
+
 .campaign-tag {
     display: inline-block;
-    background: rgba(255,255,255,0.15);
-    padding: 4px 12px;
-    border-radius: 50px;
+    background: rgba(255,255,255,0.18);
+    padding: 4px 10px;
+    border-radius: 999px;
     font-size: 0.8rem;
-    font-weight: 500;
+    font-weight: 700;
     margin-bottom: 1rem;
 }
 .campaign-card h3 { margin-bottom: 0.5rem; }
@@ -327,22 +365,23 @@ button:focus,
 .visitor-card {
     background: var(--color-light);
     border-radius: var(--radius);
-    box-shadow: var(--shadow-soft);
+    border: 1px solid var(--border-soft);
+    box-shadow: none;
     overflow: hidden;
-    text-align: center;
+    text-align: left;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 .visitor-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 35px rgba(0,0,0,0.1);
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-soft);
 }
 .visitor-card-image {
     width: 100%;
-    height: 200px;
+    height: 220px;
     object-fit: cover;
 }
 .visitor-card-content {
-    padding: 1.5rem;
+    padding: 1.35rem;
 }
 .visitor-card-content h4 {
     margin-bottom: 0.5rem;
@@ -359,6 +398,8 @@ button:focus,
     width: 100%;
     border-radius: var(--radius);
     box-shadow: var(--shadow-soft);
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
 }
 .feature-list {
     list-style: none;
@@ -372,44 +413,39 @@ button:focus,
     margin-bottom: 1rem;
 }
 .feature-list li::before {
-    content: '✓';
+    content: '';
     position: absolute;
     left: 0;
-    top: 0;
-    color: var(--color-light);
-    background: var(--gradient-primary);
-    width: 20px;
-    height: 20px;
+    top: 0.25rem;
+    background: var(--color-accent);
+    width: 10px;
+    height: 10px;
     border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.8rem;
-    font-weight: bold;
 }
 
 /* Message & Partner Cards */
 .message-card, .partner-card {
     background: var(--color-light);
     border-radius: var(--radius);
-    box-shadow: var(--shadow-soft);
+    border: 1px solid var(--border-soft);
+    box-shadow: none;
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 .message-card:hover, .partner-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 35px rgba(0,0,0,0.1);
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-soft);
 }
 .message-card img {
     width: 100%;
-    height: 200px;
+    height: 210px;
     object-fit: cover;
 }
 .message-content { padding: 1.5rem; }
 .message-content h4 { margin-bottom: 0.5rem; }
 .message-link {
     font-weight: 700;
-    color: var(--color-primary-start);
+    color: var(--color-primary-end);
 }
 .partner-card {
     padding: 2rem;
@@ -429,7 +465,7 @@ button:focus,
     top: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: rgba(16, 15, 13, 0.58);
     backdrop-filter: blur(5px);
 }
 
@@ -443,7 +479,7 @@ button:focus,
     max-height: 90vh;
     text-align: center;
     position: relative;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.24);
     overflow-y: auto;
 }
 
@@ -502,7 +538,7 @@ button:focus,
 }
 
 .bank-transfer-section h4 {
-    color: var(--color-primary-start);
+    color: var(--color-primary-end);
     margin-bottom: 1rem;
     text-align: center;
 }
@@ -531,7 +567,7 @@ button:focus,
 
 .qr-card {
     background-color: var(--color-light);
-    border: 2px solid var(--bg-light);
+    border: 1px solid var(--border-soft);
     border-radius: var(--radius);
     padding: 1.5rem;
     text-align: center;
@@ -566,7 +602,7 @@ button:focus,
 
 .qr-label {
     font-weight: 700;
-    color: var(--color-primary-start);
+    color: var(--color-primary-end);
     margin: 0.5rem 0 1rem 0;
     text-transform: uppercase;
     font-size: 0.9rem;
@@ -583,9 +619,9 @@ button:focus,
 
 /* --- 6. FOOTER --- */
 .main-footer {
-    background: #222;
-    color: var(--color-grey);
-    padding: 2rem;
+    background: #222132;
+    color: #b8b5c7;
+    padding: 3rem 2rem;
     text-align: center;
     display: flex;
     flex-direction: column;
@@ -596,8 +632,22 @@ button:focus,
 
 .anchor-scripture-card {
     margin: 0 auto 2rem auto;
-    max-width: 600px;
+    max-width: 760px;
     text-align: center;
+}
+
+.scripture-text {
+    color: #eceaf5;
+    font-size: 1rem;
+    line-height: 1.8;
+}
+
+.scripture-text cite {
+    color: var(--color-accent);
+    display: block;
+    font-style: normal;
+    font-weight: 700;
+    margin-top: 0.8rem;
 }
 
 .scripture-image {
@@ -628,7 +678,7 @@ button:focus,
 }
 
 .social-links a:hover {
-    color: var(--color-primary-start);
+    color: var(--color-accent);
 }
 
 /* --- 7. RESPONSIVE DESIGN --- */
@@ -645,24 +695,18 @@ button:focus,
 }
 
 @media (max-width: 992px) {
-    .navbar { height: 60px; }
-    .logo img { height: 30px; }
-    .nav-links-main a { font-size: 0.9rem; padding: 0.2rem 0; }
+    .navbar { height: 66px; }
+    .logo img { height: 34px; }
+    .nav-links-main a { font-size: 0.95rem; padding: 0.55rem 1rem; }
     .nav-actions { gap: 1rem; }
     .btn-lang { padding: 6px 16px; font-size: 0.8rem; }
 
     .hero-content h1 { font-size: 3rem; }
     .hero-content .subtitle-hero { font-size: 1.2rem; }
     .hero-content .tagline { font-size: 1rem; }
-    .hero-icon-circle {
-        width: 60px;
-        height: 60px;
-        font-size: 2.5rem;
-        margin-bottom: 1rem;
-    }
     .hero-section {
-        padding-top: calc(60px + 1.5rem);
-        padding-bottom: 100px;
+        padding-top: 4rem;
+        padding-bottom: 7rem;
     }
     .hero-info-cards {
         bottom: 1.5rem;
@@ -671,6 +715,9 @@ button:focus,
         padding: 1rem 1.5rem;
         font-size: 0.9rem;
         gap: 0.75rem;
+    }
+    .info-card span {
+        white-space: normal;
     }
     .info-card img { height: 24px; }
 
@@ -682,9 +729,11 @@ button:focus,
         width: 100%;
         text-align: center;
         position: absolute;
-        top: 60px;
+        top: 66px;
         left: 0;
-        background: var(--color-light);
+        background: rgba(255, 255, 255, 0.98);
+        border: 1px solid var(--border-soft);
+        border-radius: 0 0 var(--radius) var(--radius);
         box-shadow: var(--shadow-soft);
         padding: 1rem 0;
     }
@@ -763,13 +812,13 @@ button:focus,
     }
     
     .hero-info-cards {
-        position: static; /* Moved here from global scope */
+        position: static;
         flex-direction: column;
-        transform: none; /* Reset transform for static positioning */
+        transform: none;
         margin-top: 2rem;
         align-items: center;
-        width: 100%;
-        padding: 0 1rem;
+        width: min(100% - 2rem, 420px);
+        padding: 0;
     }
     .info-card {
         width: 100%;
@@ -777,17 +826,19 @@ button:focus,
     }
     .hero-section {
         padding-bottom: 4rem;
+        text-align: center;
     }
     h1 { font-size: 2.25rem; }
     h2 { font-size: 1.8rem; }
     .hero-content h1 { font-size: 2.5rem; }
     .hero-content .subtitle-hero { font-size: 1rem; }
     .hero-content .tagline { font-size: 0.9rem; }
-    .hero-icon-circle {
-        width: 50px;
-        height: 50px;
-        font-size: 2rem;
-        margin-bottom: 1rem;
+    .hero-content {
+        align-items: center;
+        width: min(100% - 2rem, 560px);
+    }
+    .hero-actions {
+        justify-content: center;
     }
     
     
@@ -820,27 +871,28 @@ button:focus,
 /* Add a little margin-top to the main to avoid overlap with fixed header */
 main {
     flex-grow: 1;
-    margin-top: 70px;
+    margin-top: 76px;
 }
 /* Re-adjust hero-section padding-top to account for the margin-top on main */
 .hero-section {
-    padding-top: 2rem;
+    padding-top: 5rem;
 }
 /* Adjust hero content for vertical centering within the remaining space */
 .hero-content {
-    flex-grow: 1;
+    flex-grow: 0;
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
-    padding-bottom: 6rem;
+    padding-bottom: 0;
 }
 
 /* --- 8. EVENTS SECTION --- */
 .event-card {
     background: var(--color-light);
     border-radius: var(--radius);
-    box-shadow: var(--shadow-soft);
+    border: 1px solid var(--border-soft);
+    box-shadow: none;
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     max-width: 800px;
@@ -848,8 +900,8 @@ main {
 }
 
 .event-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 35px rgba(0,0,0,0.1);
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-soft);
 }
 
 .event-image {
@@ -867,7 +919,7 @@ main {
 }
 
 .event-content h3 {
-    color: var(--color-primary-start);
+    color: var(--color-primary-end);
     margin-bottom: 1rem;
     font-size: 1.8rem;
 }
@@ -896,7 +948,8 @@ main {
     display: none;
     background: var(--color-light);
     border-radius: var(--radius);
-    box-shadow: var(--shadow-soft);
+    border: 1px solid var(--border-soft);
+    box-shadow: none;
     overflow: hidden;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     max-width: 400px;
@@ -904,8 +957,8 @@ main {
 }
 
 .mobile-event-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 15px 35px rgba(0,0,0,0.1);
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-soft);
 }
 
 .mobile-event-image {
@@ -923,7 +976,7 @@ main {
 }
 
 .mobile-event-content h3 {
-    color: var(--color-primary-start);
+    color: var(--color-primary-end);
     margin-bottom: 0.75rem;
     font-size: 1.4rem;
 }
@@ -960,7 +1013,8 @@ main {
 .no-events-message {
     background: var(--color-light);
     border-radius: var(--radius);
-    box-shadow: var(--shadow-soft);
+    border: 1px solid var(--border-soft);
+    box-shadow: none;
     padding: 3rem 2rem;
     max-width: 600px;
     margin: 2rem auto;
@@ -984,7 +1038,7 @@ main {
 }
 
 .ministry-flip-card:focus {
-    outline: 2px solid var(--color-primary-start);
+    outline: 2px solid var(--color-accent);
     outline-offset: 4px;
     border-radius: var(--radius);
 }
@@ -1010,7 +1064,8 @@ main {
     backface-visibility: hidden;
     border-radius: var(--radius);
     overflow: hidden;
-    box-shadow: var(--shadow-soft);
+    border: 1px solid var(--border-soft);
+    box-shadow: none;
 }
 
 .ministry-flip-card-back {
@@ -1028,6 +1083,53 @@ main {
   .grid-3-col .ministry-flip-card:last-child:nth-child(3n + 1) {
     grid-column-start: 2;
   }
+}
+
+@media (max-width: 992px) {
+    main {
+        margin-top: 66px;
+    }
+
+    .hero-section {
+        min-height: calc(100vh - 66px);
+        padding-top: 4rem;
+        padding-bottom: 7rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .container {
+        padding: 0 1.25rem;
+    }
+
+    .page-section {
+        padding: 4rem 0;
+    }
+
+    .hero-section {
+        padding: 4rem 0;
+        text-align: center;
+    }
+
+    .hero-content {
+        align-items: center;
+        width: min(100% - 2rem, 560px);
+    }
+
+    .hero-actions {
+        justify-content: center;
+    }
+
+    .hero-actions .btn {
+        width: 100%;
+        max-width: 280px;
+        text-align: center;
+    }
+
+    .visitor-card,
+    .message-card {
+        text-align: left;
+    }
 }
 
 


### PR DESCRIPTION
Updates the RCN Dallas site with a subtle RCN North America-inspired layout while preserving the purple identity, bilingual content, ministries, giving flow, and existing assets. Refreshes the desktop navigation and hero service panels, improves responsive card styling, updates current Dallas content, and removes the expired June 6 event. Verified inline JavaScript parsing, all 29 local asset references, desktop and mobile overflow, navigation, language switching, and the giving modal.