### PR TITLE
Show Mid-Year as campaign card

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,15 +79,18 @@
         <section class="page-section bg-light" id="current-campaigns-section">
             <div class="container">
                 <h2 class="section-title" data-i18n="section_title_campaigns">Current Campaigns</h2>
-                <div class="campaign-single campaign-feature">
-                    <div class="event-card campaign-event-card">
-                        <img src="images/events/mid-year-nightly-prayers.png" alt="Mid-Year Nightly Prayers flyer" class="event-image event-flyer campaign-flyer" loading="lazy">
-                        <div class="event-content">
-                            <span class="campaign-tag campaign-tag-light" data-i18n="event_midyear_tag">Active Campaign</span>
-                            <h3 data-i18n="event_midyear_title">Mid-Year Nightly Prayers</h3>
-                            <p data-i18n="event_midyear_desc">Join us nightly from July 1-31, 2026 at 11PM CST on Zoom with Rev. Philip Gbir.</p>
-                            <a href="https://chat.whatsapp.com/LNBlcBaH5XF3JwosqkcpNJ?mode=gi_t" class="btn btn-primary" data-i18n="btn_join_now" target="_blank">Join Now</a>
-                        </div>
+                <div class="grid-2-col campaign-grid">
+                    <div class="campaign-card style-2">
+                        <span class="campaign-tag" data-i18n="campaign_active_tag">Active Campaign</span>
+                        <h3 data-i18n="campaign_promise_title">Midday Prayers: Every Day at Noon</h3>
+                        <p data-i18n="campaign_promise_desc">Join us daily at 12PM CDT for powerful midday prayers on Zoom.</p>
+                        <a href="https://chat.whatsapp.com/LNBlcBaH5XF3JwosqkcpNJ?mode=gi_t" class="btn btn-light" data-i18n="btn_join_now" target="_blank">Join Now</a>
+                    </div>
+                    <div class="campaign-card style-2">
+                        <span class="campaign-tag" data-i18n="event_midyear_tag">Active Campaign</span>
+                        <h3 data-i18n="event_midyear_title">Mid-Year Nightly Prayers</h3>
+                        <p data-i18n="event_midyear_desc">Join us nightly from July 1-31, 2026 at 11PM CST on Zoom with Rev. Philip Gbir.</p>
+                        <a href="https://chat.whatsapp.com/LNBlcBaH5XF3JwosqkcpNJ?mode=gi_t" class="btn btn-light" data-i18n="btn_join_now" target="_blank">Join Now</a>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -346,6 +346,11 @@ button:focus,
     margin: 0 auto;
 }
 
+.campaign-grid {
+    max-width: 980px;
+    margin: 0 auto;
+}
+
 .campaign-tag {
     display: inline-block;
     background: rgba(255,255,255,0.18);
@@ -920,27 +925,6 @@ main {
     object-fit: cover;
     object-position: center top;
     background: var(--bg-light);
-}
-
-.campaign-feature {
-    max-width: 700px;
-}
-
-.campaign-event-card {
-    text-align: center;
-}
-
-.campaign-event-card .event-content {
-    padding: 2rem;
-}
-
-.campaign-flyer {
-    height: 560px;
-}
-
-.campaign-tag-light {
-    background: var(--color-panel);
-    color: var(--color-primary-end);
 }
 
 .event-image {


### PR DESCRIPTION
Updates Current Campaigns to show Mid-Year Nightly Prayers as a no-flyer purple campaign card alongside Midday Prayers. Keeps One Accord and Dwelling Together in Upcoming Events.